### PR TITLE
support aws, remove json file arg

### DIFF
--- a/aws/util.sh
+++ b/aws/util.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# GCE specific utility (helper) functions. Expected to live in the "gce/" directory.
+# AWS specific utility (helper) functions. Expected to live in the "aws/" directory.
 # All providers are expected to support the following functions:
 #	util::get_instance_info
 #	util::xyzzy
@@ -9,38 +9,38 @@
 # util::get_instance_info: based on the passed in instance-filter, return a map (as a string)
 # which includes the following keys:
 #	NAMES   - list of instance dns names
-#	IDS     - list of ids (empty for gce)
-#	ZONES   - list of gce zones
+#	IDS     - list of ids
+#	ZONES   - list of zones (empty for aws)
 #	IPS_INT - list of cluster internal ips
 #	IPS_EXT - list of external (public) ips
 # Note: caller should 'declare -A map_var' before assigning to this function's return. Eg:
 #	declare -A map=$(util::get_instance_info $filter)
 #
 function util::get_instance_info() {
-	readonly filter="$1"
-	readonly format='value(name,zone,networkInterfaces[].networkIP,networkInterfaces[].accessConfigs[0].natIP)'
-	# ^ in key order: NAMES, ZONES, IPS_INT, IPS_EXT
+	readonly filter="Name=tag:Name,Values='*$1*'"
+	readonly query='Reservations[*].Instances[*].[PublicDnsName,InstanceId,PrivateIpAddress,PublicIpAddress]'
+	# ^ in key order: NAMES, IDS, IPS_INT, IPS_EXT
 	local info
 
-	info="$(gcloud compute instances list --filter="$filter" --format="$format")"
+	info="$(aws ec2 --output text describe-instances --filter $filter --query $query)"
 	if (( $? != 0 )); then
-		echo "error: failed to get gce info (NAMES, ZONES, IPs)" >&2
+		echo "error: failed to get aws info (NAMES, IDs, IPs)" >&2
 		return 1
 	fi
 	if [[ -z "$info" ]]; then
-		echo "error: retrieved gce info is empty" >&2
+		echo "error: retrieved aws info is empty" >&2
 		return 1
 	fi
 	# parse info into lists
-	local rec; local names; local zones; local int_ips; local ext_ips
+	local rec; local names; local ids; local int_ips; local ext_ips
 	while IFS= read -r rec; do
 		names+="$(awk '{print $1}' <<<"$rec") "
-		zones+="$(awk '{print $2}' <<<"$rec") "
+		ids+="$(awk '{print $2}' <<<"$rec") "
 		int_ips+="$(awk '{print $3}' <<<"$rec") "
 		ext_ips+="$(awk '{print $4}' <<<"$rec") "
 	done <<<"$info"
 	local map
-	map="([NAMES]='$names', [IDS]='', [ZONES]='$zones', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
+	map="([NAMES]='$names', [IDS]='$ids', [ZONES]='', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
 	echo "$map"
 	return 0
 }


### PR DESCRIPTION
add aws support to `gen-ep.sh`. Also removes the optional json file name arg. Simple output redirection can be used to generate the json file. Last, all errors are now echo'd to $stderr.