### PR TITLE
callers of util::get_instance_info can pass in 1 or more keys

### DIFF
--- a/aws/util.sh
+++ b/aws/util.sh
@@ -6,42 +6,76 @@
 #	util::xyzzy
 #
 
-# util::get_instance_info: based on the passed in instance-filter, return a map (as a string)
-# which includes the following keys:
-#	NAMES   - list of instance dns names
-#	IDS     - list of ids
-#	ZONES   - list of zones (empty for aws)
-#	IPS_INT - list of cluster internal ips
-#	IPS_EXT - list of external (public) ips
+# util::get_instance_info: based on the passed in instance-filter and optional key(s), return a map
+# (as a string) which includes one of more of the following keys:
+#	NAMES       - list of instance dns names
+#	IDS         - list of ids
+#	PRIVATE_IPS - list of cluster internal ips
+#	PUBLIC_IPS  - list of external ips
+# Args: 1=instance-filter (required), 2+=zero or more map keys separated by spaces. If no key is
+#       provided then all key values are returned.
 # Note: caller should 'declare -A map_var' before assigning to this function's return. Eg:
 #	declare -A map=$(util::get_instance_info $filter)
 #
 function util::get_instance_info() {
-	readonly filter="Name=tag:Name,Values='*$1*'"
-	readonly query='Reservations[*].Instances[*].[PublicDnsName,InstanceId,PrivateIpAddress,PublicIpAddress]'
-	# ^ in key order: NAMES, IDS, IPS_INT, IPS_EXT
-	local info
+	local filter="Name=tag:Name,Values='*$1*'"
+	shift; local keys=($@) # array
+	local query="Reservations[*].Instances[*].["
 
-	info="$(aws ec2 --output text describe-instances --filter $filter --query $query)"
+	(( ${#keys[@]} == 0 )) && keys=(NAMES IDS PRIVATE_IPS PUBLIC_IPS) #all
+	local key
+	for key in ${keys[@]}; do
+		case $key in
+			NAMES)	     query+='PublicDnsName,';;
+			IDS)         query+='InstanceId,';;
+			PRIVATE_IPS) query+='PrivateIpAddress,';;
+			PUBLIC_IPS)  query+='PublicIpAddress,';;
+			*)	     echo "Unknown aws info key: $key" >&2; return 1;;
+		esac
+	done
+	query="${query::-1}" # remove last comma
+	query+=']'
+	
+	# retrieve aws ec2 info
+	local info=()
+	info=($(aws ec2 --output text describe-instances --filter="$filter" --query="$query"))
 	if (( $? != 0 )); then
-		echo "error: failed to get aws info (NAMES, IDs, IPs)" >&2
+		echo "error: failed to get aws info for keys: ${keys[@]}" >&2
 		return 1
 	fi
-	if [[ -z "$info" ]]; then
-		echo "error: retrieved aws info is empty" >&2
+	if (( ${#info[@]}  == 0 )); then
+		echo "error: retrieved aws info is empty, keys: ${keys[@]}" >&2
 		return 1
 	fi
-	# parse info into lists
-	local rec; local names; local ids; local int_ips; local ext_ips
-	while IFS= read -r rec; do
-		names+="$(awk '{print $1}' <<<"$rec") "
-		ids+="$(awk '{print $2}' <<<"$rec") "
-		int_ips+="$(awk '{print $3}' <<<"$rec") "
-		ext_ips+="$(awk '{print $4}' <<<"$rec") "
-	done <<<"$info"
-	local map
-	map="([NAMES]='$names', [IDS]='$ids', [ZONES]='', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
-	echo "$map"
+	# parse info results into separate lists
+	local i; local j; local names; local ids; local private_ips; local public_ips; local value
+	for ((i=0; i<${#info[@]}; )); do
+		for key in ${keys[@]}; do
+			value="${info[$i]}"
+			case $key in
+				NAMES)       names+="$value ";;
+				IDS)         ids+="$value ";;
+				PRIVATE_IPS) private_ips+="$value ";;
+				PUBLIC_IPS)  public_ips+="$value ";;
+			esac	
+			((i++))
+		done
+	done
+
+	# construct map
+	local map='('
+	for key in ${keys[@]}; do
+		map+="[$key]="
+		case $key in
+			NAMES)       map+="'$names', ";;
+			IDS)         map+="'$ids', ";;
+			PRIVATE_IPS) map+="'$private_ips', ";;
+			PUBLIC_IPS)  map+="'$public_ips', ";;
+		esac
+	done
+	map="${map::-2}" # remove last ", "
+        map+=')'
+	echo "$map" # return json string
 	return 0
 }
 

--- a/gce/util.sh
+++ b/gce/util.sh
@@ -6,42 +6,76 @@
 #	util::xyzzy
 #
 
-# util::get_instance_info: based on the passed in instance-filter, return a map (as a string)
-# which includes the following keys:
-#	NAMES   - list of instance dns names
-#	IDS     - list of ids (empty for gce)
-#	ZONES   - list of gce zones
-#	IPS_INT - list of cluster internal ips
-#	IPS_EXT - list of external (public) ips
+# util::get_instance_info: based on the passed in instance-filter and optional key(s), return a map
+# (as a string) which includes one of more of the following keys:
+#	NAMES       - list of instance dns names
+#	ZONES       - list of zones
+#	PRIVATE_IPS - list of cluster internal ips
+#	PUBLIC_IPS  - list of external ips
+# Args: 1=instance-filter (required), 2+=zero or more map keys separated by spaces. If no key is
+#       provided then all key values are returned.
 # Note: caller should 'declare -A map_var' before assigning to this function's return. Eg:
 #	declare -A map=$(util::get_instance_info $filter)
 #
 function util::get_instance_info() {
-	readonly filter="$1"
-	readonly format='value(name,zone,networkInterfaces[].networkIP,networkInterfaces[].accessConfigs[0].natIP)'
-	# ^ in key order: NAMES, ZONES, IPS_INT, IPS_EXT
-	local info
+	local filter="$1"
+	shift; local keys=($@) # array
+	local query='value('
 
-	info="$(gcloud compute instances list --filter="$filter" --format="$format")"
+	(( ${#keys[@]} == 0 )) && keys=(NAMES ZONES PRIVATE_IPS PUBLIC_IPS) #all
+	local key
+	for key in ${keys[@]}; do
+		case $key in
+			NAMES)	     query+='name,';;
+			ZONES)       query+='zone,';;
+			PRIVATE_IPS) query+='networkInterfaces[].networkIP,';;
+			PUBLIC_IPS)  query+='networkInterfaces[].accessConfigs[0].natIP,';;
+			*)	     echo "Unknown gce info key: $key" >&2; return 1;;
+		esac
+	done
+	query="${query::-1}" # remove last comma
+	query+=')'
+	
+	# retrieve gce instance info
+	local info=()
+	info=($(gcloud compute instances list --filter="$filter" --format="$query"))
 	if (( $? != 0 )); then
-		echo "error: failed to get gce info (NAMES, ZONES, IPs)" >&2
+		echo "error: failed to get gce info for keys: $keys" >&2
 		return 1
 	fi
-	if [[ -z "$info" ]]; then
-		echo "error: retrieved gce info is empty" >&2
+	if (( ${#info[@]}  == 0 )); then
+		echo "error: retrieved gce info is empty, keys: $keys" >&2
 		return 1
 	fi
-	# parse info into lists
-	local rec; local names; local zones; local int_ips; local ext_ips
-	while IFS= read -r rec; do
-		names+="$(awk '{print $1}' <<<"$rec") "
-		zones+="$(awk '{print $2}' <<<"$rec") "
-		int_ips+="$(awk '{print $3}' <<<"$rec") "
-		ext_ips+="$(awk '{print $4}' <<<"$rec") "
-	done <<<"$info"
-	local map
-	map="([NAMES]='$names', [IDS]='', [ZONES]='$zones', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
-	echo "$map"
+	# parse info results into separate lists
+	local i; local j; local names; local zones; local private_ips; local public_ips; local value
+	for ((i=0; i<${#info[@]}; )); do
+		for key in ${keys[@]}; do
+			value="${info[$i]}"
+			case $key in
+				NAMES)       names+="$value ";;
+				ZONES)       zones+="$value ";;
+				PRIVATE_IPS) private_ips+="$value ";;
+				PUBLIC_IPS)  public_ips+="$value ";;
+			esac	
+			((i++))
+		done
+	done
+
+	# construct map
+	local map='('
+	for key in ${keys[@]}; do
+		map+="[$key]="
+		case $key in
+			NAMES)       map+="'$names', ";;
+			ZONES)       map+="'$zones', ";;
+			PRIVATE_IPS) map+="'$private_ips', ";;
+			PUBLIC_IPS)  map+="'$public_ips', ";;
+		esac
+	done
+	map="${map::-2}" # remove last ", "
+        map+=')'
+	echo "$map" # return json string
 	return 0
 }
 

--- a/gen-ep.sh
+++ b/gen-ep.sh
@@ -17,12 +17,12 @@ function make_ep_json() {
 	local ip
 	local subsets
 
-	for ip in ${INSTMAP[INT_IPS]}; do
+	for ip in ${INSTMAP[PRIVATE_IPS]}; do
 		subsets+="{'addresses':[{'ip':'$ip'}],'ports':[{'port':1}]},"
 	done
 	subsets="${subsets::-1}" # remove last comma
 	local ep
-	ep="
+	ep="\
 {
   'kind': 'Endpoints',
   'apiVersion': 'v1',
@@ -39,7 +39,7 @@ function make_ep_json() {
 
 ## main ##
 
-cat <<END
+cat <<END >&2
 
    This script outputs endpoints json based on the supplied provider and filter, suitable for
    'kubectl create -f'.  Redirect output to capture the output in a file.
@@ -67,8 +67,8 @@ if [[ -z "$FILTER" ]]; then
 	exit 1
 fi
 
-echo "   Creating endpoints json for $PROVIDER ($FILTER)..."
-echo
+echo "   Creating endpoints json for $PROVIDER ($FILTER)..." >&2
+echo >&2
 
 # source util functions based on provider
 ROOT="$(dirname '${BASH_SOURCE}')"
@@ -84,13 +84,11 @@ fi
 source $UTIL
 
 # get internal ips from provider
-rtn=$(util::get_instance_info $FILTER)
+declare -A INSTMAP=$(util::get_instance_info $FILTER PRIVATE_IPS)
 if (( $? != 0 )); then
 	echo "failed to get $PROVIDER instance info:" >&2
-	echo $rtn >&2
 	exit 1
 fi
-declare -A INSTMAP=$rtn
 
 # create endpoint json
 json="$(make_ep_json)"


### PR DESCRIPTION
Made `util::get_instance_info` more flexible/efficient by allowing the callers to specify which key(s) they want info for. Also, fixed bugs related to the user redirecting `gen-ep.sh` output to a file where some of the echos were written to stdout instead of stderr.

Maybe a separate pr can consolidate the common code in the 2 _util.sh_ files?