### PR TITLE
init.sh to load env based on provider

### DIFF
--- a/aws/util.sh
+++ b/aws/util.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# GCE specific utility (helper) functions. Expected to live in the "gce/" directory.
+# AWS specific utility (helper) functions. Expected to live in the "aws/" directory.
 # All providers are expected to support the following functions:
 #	util::get_instance_info
 #	util::xyzzy
@@ -9,37 +9,38 @@
 # util::get_instance_info: based on the passed in instance-filter, return a map (as a string)
 # which includes the following keys:
 #	NAMES   - list of instance dns names
-#	IDS     - list of ids (empty for gce)
-#	ZONES   - list of gce zones
+#	IDS     - list of ids
+#	ZONES   - list of zones (empty for aws)
 #	IPS_EXT - list of external (public) ips
 #	IPS_INT - list of cluster internal ips
 # Note: caller should 'declare -A map_var' before assigning to this function's return. Eg:
 #	declare -A map=$(util::get_instance_info $filter)
 #
 function util::get_instance_info() {
-	readonly filter="$1"
-	readonly format='value(name,zone,networkInterfaces[].networkIP,networkInterfaces[].accessConfigs[0].natIP)'
+	readonly filter="Name=tag:Name,Values='*$1*'"
+	readonly query='Reservations[*].Instances[*].[PublicDnsName,InstanceId,PrivateIpAddress,PublicIpAddress]'
+	# ^ in key order: NAMES, IDS, IPS_EXT, IPS_INT
 	local info
 
-	info="$(gcloud compute instances list --filter="$filter" --format="$format")"
+	info="$(aws ec2 --output text describe-instances --filter $filter --query $query)"
 	if (( $? != 0 )); then
-		echo "error: failed to get gce info (NAMES, ZONES, IPs)" >&2
+		echo "error: failed to get aws info (NAMES, IDs, IPs)" >&2
 		return 1
 	fi
 	if [[ -z "$info" ]]; then
-		echo "error: retrieved gce info is empty" >&2
+		echo "error: retrieved aws info is empty" >&2
 		return 1
 	fi
 	# parse info into lists
-	local rec; local names; local zones; local int_ips; local ext_ips
+	local rec; local names; local ids; local int_ips; local ext_ips
 	while IFS= read -r rec; do
 		names+="$(awk '{print $1}' <<<"$rec") "
-		zones+="$(awk '{print $2}' <<<"$rec") "
+		ids+="$(awk '{print $2}' <<<"$rec") "
 		int_ips+="$(awk '{print $3}' <<<"$rec") "
 		ext_ips+="$(awk '{print $4}' <<<"$rec") "
 	done <<<"$info"
 	local map
-	map="([NAMES]='$names', [IDS]='', [ZONES]='$zones', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
+	map="([NAMES]='$names', [IDS]='$ids', [ZONES]='', [INT_IPS]='$int_ips', [EXT_IPS]='$ext_ips')"
 	echo "$map"
 	return 0
 }

--- a/aws/util.sh
+++ b/aws/util.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# AWS specific utility (helper) functions. Expected to live in the "aws/" directory.
+# AWS specific utility (helper) functions. Expected to live in the "aws/" directory. Function names must
+# be prefixed with "util::".
 # All providers are expected to support the following functions:
 #	util::get_instance_info
-#	util::xyzzy
 #
 
 # util::get_instance_info: based on the passed in instance-filter and optional key(s), return a map

--- a/gce/util.sh
+++ b/gce/util.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# GCE specific utility (helper) functions. Expected to live in the "gce/" directory.
+# GCE specific utility (helper) functions. Expected to live in the "gce/" directory. Function names must
+# be prefixed with "util::".
+
 # All providers are expected to support the following functions:
 #	util::get_instance_info
-#	util::xyzzy
 #
 
 # util::get_instance_info: based on the passed in instance-filter and optional key(s), return a map

--- a/gen-ep.sh
+++ b/gen-ep.sh
@@ -50,16 +50,11 @@ cat <<END >&2
 
 END
 
+# source util funcs based on provider
+source init.sh || exit 1
+
 PROVIDER="$1"
-if [[ -z "$PROVIDER" ]]; then
-	echo "Missing required cloud-provider value" >&2
-	exit 1
-fi
-PROVIDER="$(tr '[:upper:]' '[:lower:]' <<<"$PROVIDER")"
-case $PROVIDER in
-	aws|gce) ;;
-	*) echo "Provider must be either aws or gce" >&2; exit 1 ;;
-esac
+init::load_provider $PROVIDER || exit 1
 
 FILTER="$2"
 if [[ -z "$FILTER" ]]; then
@@ -69,19 +64,6 @@ fi
 
 echo "   Creating endpoints json for $PROVIDER ($FILTER)..." >&2
 echo >&2
-
-# source util functions based on provider
-ROOT="$(dirname '${BASH_SOURCE}')"
-if [[ ! -d "$ROOT/$PROVIDER" ]]; then
-	echo "Missing $PROVIDER directory under $ROOT" >&2
-	exit 1
-fi
-UTIL="$ROOT/$PROVIDER/util.sh"
-if [[ ! -f "$UTIL" ]]; then
-	echo "Missing $UTIL" >&2
-	exit 1
-fi
-source $UTIL
 
 # get internal ips from provider
 declare -A INSTMAP=$(util::get_instance_info $FILTER PRIVATE_IPS)

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+#
+# 'init.sh' is expected to be sourced. This file include functions for initializing the
+# environment based on the cloud provider. GCE and AWS are the only providers supported
+# for now. All functions must be prefixed with "init::".
+#
+
+# init::load_provider: source the utility file based on the passed-in provider.
+# Returns 1 for errors.
+function init::load_provider() {
+	local provider="$1"
+	if [[ -z "$provider" ]]; then
+		echo "Missing required cloud-provider value" >&2
+		return 1
+	fi
+	provider="$(tr '[:upper:]' '[:lower:]' <<<"$provider")"
+	case $provider in
+		aws|gce) ;;
+		*) echo "Provider must be either aws or gce" >&2; return 1 ;;
+	esac
+
+	# source util functions based on provider
+	local root="$(dirname '${BASH_SOURCE}')"
+	if [[ ! -d "$root/$provider" ]]; then
+		echo "Missing $provider directory under $root" >&2
+		return 1
+	fi
+	local util="$root/$provider/util.sh"
+	if [[ ! -f "$util" ]]; then
+		echo "Missing $util" >&2
+		return 1
+	fi
+	source $util || return 1
+	return 0
+}


### PR DESCRIPTION
New _init.sh_ to load env based on cloud provider. Allow future wrapper scripts to share code.