### PR TITLE
updt fix-ec2-nodes to use util helpers, bug fix

### DIFF
--- a/aws/util.sh
+++ b/aws/util.sh
@@ -68,13 +68,12 @@ function util::get_instance_info() {
 	for key in ${keys[@]}; do
 		map+="[$key]="
 		case $key in
-			NAMES)       map+="'$names', ";;
-			IDS)         map+="'$ids', ";;
-			PRIVATE_IPS) map+="'$private_ips', ";;
-			PUBLIC_IPS)  map+="'$public_ips', ";;
+			NAMES)       map+="'$names' ";;
+			IDS)         map+="'$ids' ";;
+			PRIVATE_IPS) map+="'$private_ips' ";;
+			PUBLIC_IPS)  map+="'$public_ips' ";;
 		esac
 	done
-	map="${map::-2}" # remove last ", "
         map+=')'
 	echo "$map" # return json string
 	return 0

--- a/gce/util.sh
+++ b/gce/util.sh
@@ -69,13 +69,12 @@ function util::get_instance_info() {
 	for key in ${keys[@]}; do
 		map+="[$key]="
 		case $key in
-			NAMES)       map+="'$names', ";;
-			ZONES)       map+="'$zones', ";;
-			PRIVATE_IPS) map+="'$private_ips', ";;
-			PUBLIC_IPS)  map+="'$public_ips', ";;
+			NAMES)       map+="'$names' ";;
+			ZONES)       map+="'$zones' ";;
+			PRIVATE_IPS) map+="'$private_ips' ";;
+			PUBLIC_IPS)  map+="'$public_ips' ";;
 		esac
 	done
-	map="${map::-2}" # remove last ", "
         map+=')'
 	echo "$map" # return json string
 	return 0

--- a/gen-ep.sh
+++ b/gen-ep.sh
@@ -11,7 +11,6 @@
 # Example:
 #	./gen-ep.sh gce jcope >gluster-ep.json
 #	./gen-ep.sh aws jcope --scp
-#
 
 
 # Parse script options. Non-option arguments are parsed my the main script block.
@@ -78,7 +77,8 @@ cat <<END >&2
 END
 
 # source util funcs based on provider
-source init.sh || exit 1
+ROOT="$(dirname '${BASH_SOURCE}')"
+source $ROOT/init.sh || exit 1
 
 parse_options "$@" || exit 1
 


### PR DESCRIPTION
1- updt fix-ec2-nodes to use util helpers, 2- fix bug in gce & aws _util::get_instance_info()_ where the map was incorrectly formatted.
This pr is needed to for both `fix-ec2-node.sh` and `gen-ep.sh`